### PR TITLE
Fixed issue with author affiliation display

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -21,8 +21,8 @@
 
 %\author{Main~Author\\Affiliation, Country, email address\and
 %		Co-Author\\Affiliation, Country, email address}
-\IACauthor{Main~Author}{Affiliation, Country, email address}
-\IACauthor{Co-Author}{Affiliation, Country, email address}
+\IACauthor{Author}{Affiliation, Country, email address}{main}
+\IACauthor{Author}{Affiliation, Country, email address}{co}
 
 \abstract{A one paragraph abstract of no more than 400 words must be included at the beginning of the manuscript. It should be a summary and complete in itself (no references to the main body of the manuscript). The abstract should indicate the subjects dealt with within the full text and should state the objectives of the investigation. Newly-observed facts and conclusions of the experiment or argument discussed in the full text must be stated in this summary. Readers should not have to read the full text to understand the abstract. The abstract can be an updated version of the one submitted at the call-for-abstracts but its contents must not differ substantially.}
 

--- a/iac.cls
+++ b/iac.cls
@@ -27,7 +27,8 @@
 \newcommand{\IACauthor}[2]{%
 	\stepcounter{authcount}%
 	\csdef{iac@author\theauthcount}{#1}%
-	\csdef{iac@affiliation\theauthcount}{#2}}
+	\csdef{iac@affiliation\theauthcount}{#2}
+	\csdef{iac@type\theauthcount}{#3}}% #3 is the author type: "main" or "co"
 
 \setlength\parindent{12pt}
 \RequirePackage[]{caption}
@@ -74,7 +75,6 @@
   \end{@twocolumnfalse}
   ]}
 \def\@maketitle{%
-  \newpage
   \begin{center}%
     IAC--\iac@paperyear--\iac@papernumber\par%
     \vskip1em
@@ -82,18 +82,56 @@
     \vskip 1.5em%
     {\large
       \lineskip .5em%
+      % Ensure authnum is defined and initialize it
       \newcounter{authnum}%
-      \setcounter{authnum}{0}
+      \setcounter{authnum}{0}%
+      % Define affnum counter for affiliations
+      \newcounter{affnum}%
+      \setcounter{affnum}{0}%
+      
+      % Command to generate superscript letters (a, b, c, ...)
+      \newcommand{\affmark}{\stepcounter{affnum}\textsuperscript{\alph{affnum}}} 
+      
+      % Define corresponding author superscript
+      \newcommand{\correspondingmark}{\textsuperscript{*}}
+
+      % Display all authors in a single line with superscripts
+      \normalsize
       \whileboolexpr
       { test {\ifnumcomp{\value{authnum}}{<}{\theauthcount}} }%
       {\stepcounter{authnum}%
-      	\normalsize\textbf{\csuse{iac@author\theauthnum}}\par%
-		\normalsize\csuse{iac@affiliation\theauthnum}\par%
-		\vskip 1.5ex%
-	  }%
+        \textbf{\csuse{iac@author\theauthnum}}%
+        \affmark% Add alphabetic superscript
+        \ifcsstring{iac@type\theauthnum}{main}{\correspondingmark}{}% Add * if author is main
+        \ifnumcomp{\value{authnum}}{<}{\theauthcount}{, }{}%
+      }%
+      \par%
     }%
   \end{center}%
+  \vskip 1em%
+  % List affiliations as a left-aligned paragraph in italics with no hyphenation
+  \noindent
+  \setcounter{affnum}{0}%
+  \raggedright% Prevent hyphenation and align left
+  \hyphenpenalty=10000 % Disable hyphenation
+  \exhyphenpenalty=10000 % Disable explicit hyphenation
+  \normalsize
+  \whileboolexpr
+  { test {\ifnumcomp{\value{affnum}}{<}{\theauthcount}} }%
+  {\stepcounter{affnum}%
+    \textsuperscript{\alph{affnum}} \textit{\csuse{iac@affiliation\theaffnum}}\par%
+  }%
+  % Add footnote for corresponding author(s)
+  \vskip 1em%
+  \noindent\textsuperscript{*} \textit{Corresponding author(s).}\par%
+  \vskip 1.5em%
+  % Centered and bold "Abstract" title
+  \begin{center}
+    \textbf{Abstract}
+  \end{center}
   \indent\iac@abstract\par%
+  \vskip 1em%
+  \indent\iac@keywords\par%
   \vskip 4.5ex}%
   \pagestyle{fancy}%
   

--- a/iac.cls
+++ b/iac.cls
@@ -24,7 +24,7 @@
 \renewcommand{\headrulewidth}{0pt}
 
 \newcounter{authcount}
-\newcommand{\IACauthor}[2]{%
+\newcommand{\IACauthor}[3]{%
 	\stepcounter{authcount}%
 	\csdef{iac@author\theauthcount}{#1}%
 	\csdef{iac@affiliation\theauthcount}{#2}


### PR DESCRIPTION
Now, the author affiliation is displayed in italics, with superscript numbering, and left aligned. Added a new section to allow users to specify main or co author easier.